### PR TITLE
21 adjustment release

### DIFF
--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -29,4 +29,5 @@ jobs:
       - id: 'deploy'
         uses: 'google-github-actions/deploy-appengine@v1'
         with:
-          flags: '-f app_dev.yaml --version=dev-${{ steps.timestamp.outputs.value }}'
+          deliverables: app_dev.yaml
+          flags: '--version=dev-${{ steps.timestamp.outputs.value }}'

--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -29,4 +29,4 @@ jobs:
       - id: 'deploy'
         uses: 'google-github-actions/deploy-appengine@v1'
         with:
-          flags: '--version=dev-${{ steps.timestamp.outputs.value }}'
+          flags: '-f app_dev.yaml --version=dev-${{ steps.timestamp.outputs.value }}'

--- a/.github/workflows/deploy_to_prod.yml
+++ b/.github/workflows/deploy_to_prod.yml
@@ -29,4 +29,4 @@ jobs:
       - id: 'deploy'
         uses: 'google-github-actions/deploy-appengine@v1'
         with:
-          flags: '--version=prod-${{ steps.timestamp.outputs.value }}'
+          flags: '-f app_prod.yaml --version=prod-${{ steps.timestamp.outputs.value }}'

--- a/.github/workflows/deploy_to_prod.yml
+++ b/.github/workflows/deploy_to_prod.yml
@@ -29,4 +29,5 @@ jobs:
       - id: 'deploy'
         uses: 'google-github-actions/deploy-appengine@v1'
         with:
-          flags: '-f app_prod.yaml --version=prod-${{ steps.timestamp.outputs.value }}'
+          deliverables: app_prod.yaml
+          flags: '--version=prod-${{ steps.timestamp.outputs.value }}'

--- a/app_dev.yaml
+++ b/app_dev.yaml
@@ -1,0 +1,8 @@
+runtime: go120
+service: dev
+instance_class: F1
+automatic_scaling:
+  max_instances: 5
+handlers:
+- url: /.*
+  script: auto

--- a/app_dev.yaml
+++ b/app_dev.yaml
@@ -1,5 +1,5 @@
 runtime: go120
-service: dev
+service: develop
 instance_class: F1
 automatic_scaling:
   max_instances: 5

--- a/app_prod.yaml
+++ b/app_prod.yaml
@@ -1,4 +1,5 @@
 runtime: go120
+service: prod
 instance_class: F1
 automatic_scaling:
   max_instances: 5

--- a/app_prod.yaml
+++ b/app_prod.yaml
@@ -1,5 +1,5 @@
 runtime: go120
-service: prod
+service: production
 instance_class: F1
 automatic_scaling:
   max_instances: 5


### PR DESCRIPTION
devサービスへのデプロイを自動的に行なってくれるか確認
→devがすでにデプロイ済みのバージョンと名前が被っているとエラーが起きたので、サービス名をdevelopmentを変更